### PR TITLE
#172 Improve on Time report

### DIFF
--- a/cmd/dcrdata/public/js/controllers/financereport_controller.js
+++ b/cmd/dcrdata/public/js/controllers/financereport_controller.js
@@ -1058,7 +1058,7 @@ export default class extends FinanceReportController {
     }
     selectedMonth = selectedMonth < 0 ? maxMonth : selectedMonth
     let monthOptions = `<option name="month_all" value="0" ${selectedYear === 0 || selectedMonth === 0 ? 'selected' : ''}>All Months</option>`
-    for (let i = maxMonth; i >= minMonth; i--) {
+    for (let i = minMonth; i <= maxMonth; i++) {
       monthOptions += `<option name="month_${i}" value="${i}" ${selectedMonth === i ? 'selected' : ''}>${this.getMonthDisplay(i)}</option>`
     }
     this.topMonthSelectTarget.innerHTML = monthOptions

--- a/cmd/dcrdata/views/extras.tmpl
+++ b/cmd/dcrdata/views/extras.tmpl
@@ -633,7 +633,7 @@
 	data-turbolinks-suppress-warning
 ></script>
 <script
-	src="/dist/js/app.ff87919e64e9cb52.bundle.js"
+	src="/dist/js/app.97ea1ee99e91fed4.bundle.js"
 	data-turbolinks-eval="false"
 	data-turbolinks-suppress-warning
 ></script>

--- a/cmd/dcrdata/views/finance_detail.tmpl
+++ b/cmd/dcrdata/views/finance_detail.tmpl
@@ -82,7 +82,7 @@
             <table class="table report report-table v3 border-grey-2 w-auto" data-financedetail-target="domainReport"></table>
          </div>
          <div data-financedetail-target="monthlyArea" class="d-none">
-            <p class="fw-600 fs-20 mt-3">Monthly Summary</p>
+            <p class="fw-600 fs-20 mt-3">Monthly</p>
             <div class="my-2 d-flex">
                <label class="color-note-label report-tool-bar border-radius-8 future-color"></label>
                <span class="c-grey-2 ps-2 fw-600 color-description">Months in the future</span>
@@ -96,7 +96,7 @@
             </table>
          </div>
          <div data-financedetail-target="yearlyArea" class="d-none">
-            <p class="fw-600 fs-20 mt-3">Yearly Summary</p>
+            <p class="fw-600 fs-20 mt-3">Yearly</p>
             <div class="my-2 d-flex">
                <label class="color-note-label report-tool-bar border-radius-8 future-color"></label>
                <span class="c-grey-2 ps-2 fw-600 color-description">Years in the future</span>

--- a/cmd/dcrdata/views/finance_report.tmpl
+++ b/cmd/dcrdata/views/finance_report.tmpl
@@ -352,20 +352,8 @@
                                  </div>
                               </div>
                            </div>
-                           <div class="mt-1 d-none" data-financereport-target="totalSpanRow">
-                              <p class="fw-600 fs-20 mt-3">Treasury</p>
-                              <table class="table report report-table v3 border-grey-2 w-auto" data-financereport-target="yearMonthInfoTable"></table>
-                           </div>
-                           <div class="d-none" data-financereport-target="domainSummaryArea">
-                              <p class="fw-600 fs-20 mt-2">Domains</p>
-                              <table class="table report report-table v3 border-grey-2 w-auto" data-financereport-target="domainSummaryTable"></table>
-                           </div>
-                           <p class="d-none mt-2" data-financereport-target="noReport">Data does not exist. Let's move on to another time!</p>
-                           <div data-financereport-target="domainArea" class="d-none">
-                              <p class="fw-600 fs-20 mt-3">Domain Data (Est)</p>
-                              <table class="table report report-table v3 border-grey-2 w-auto" data-financereport-target="domainReport"></table>
-                           </div>
                            <div data-financereport-target="monthlyArea" class="d-none">
+                              <div>
                               <p class="fw-600 fs-20 mt-3">Group By Time</p>
                               <div class="my-2 d-flex">
                                  <label class="color-note-label report-tool-bar border-radius-8 future-color"></label>
@@ -383,12 +371,31 @@
                               <div class="d-flex" data-financereport-target="monthlyReport">
                               </div>
                            </div>
+                           </div>
+                           <div class="mt-1 d-iflex d-none me-2 me-md-3 me-lg-5" data-financereport-target="totalSpanRow">
+                              <div>
+                                 <p class="fw-600 fs-20 mt-3">Treasury</p>
+                                 <table class="table report report-table v3 border-grey-2 w-auto" data-financereport-target="yearMonthInfoTable"></table>
+                              </div>
+                           </div>
+                           <div class="d-none d-iflex me-2 me-md-3 me-lg-5" data-financereport-target="domainSummaryArea">
+                              <div>
+                                 <p class="fw-600 fs-20 mt-2">Domains</p>
+                                 <table class="table report report-table v3 border-grey-2 w-auto" data-financereport-target="domainSummaryTable"></table>
+                              </div>
+                           </div>
+                           <p class="d-none mt-2" data-financereport-target="noReport">Data does not exist. Let's move on to another time!</p>
+                           <div data-financereport-target="domainArea" class="d-none">
+                              <p class="fw-600 fs-20 mt-3">Domain Data (Est)</p>
+                              <table class="table report report-table v3 border-grey-2 w-auto" data-financereport-target="domainReport"></table>
+                           </div>
                            <div data-financereport-target="proposalArea" class="d-none">
                               <p class="fw-600 fs-20 mt-3">Proposals</p>
                               <table class="table report report-table v3 border-grey-2 w-auto" data-financereport-target="proposalReport">
                               </table>
                            </div>
                            <div data-financereport-target="yearlyArea" class="d-none">
+                              <div>
                               <p class="fw-600 fs-20 mt-3">Yearly</p>
                               <div class="my-2 d-flex">
                                  <label class="color-note-label report-tool-bar border-radius-8 future-color"></label>
@@ -396,6 +403,7 @@
                               </div>
                               <div class="d-flex" data-financereport-target="yearlyReport">
                               </div>
+                           </div>
                            </div>
                            <div data-financereport-target="sameOwnerProposalArea" class="d-none">
                               <p class="fw-600 fs-20 mt-3">Proposals with the same owner</p>

--- a/cmd/dcrdata/views/finance_report.tmpl
+++ b/cmd/dcrdata/views/finance_report.tmpl
@@ -351,14 +351,14 @@
                                     <p class="fs-15" data-financereport-target="unaccountedValueArea">Delta: <span class="fw-600" data-financereport-target="unaccountedValue"></span></p>
                                  </div>
                               </div>
-                              <div class="d-none" data-financereport-target="domainSummaryArea">
-                                 <p class="fw-600 fs-20 mt-2">Domains</p>
-                                 <table class="table report report-table v3 border-grey-2 w-auto" data-financereport-target="domainSummaryTable"></table>
-                              </div>
                            </div>
                            <div class="mt-1 d-none" data-financereport-target="totalSpanRow">
                               <p class="fw-600 fs-20 mt-3">Treasury</p>
                               <table class="table report report-table v3 border-grey-2 w-auto" data-financereport-target="yearMonthInfoTable"></table>
+                           </div>
+                           <div class="d-none" data-financereport-target="domainSummaryArea">
+                              <p class="fw-600 fs-20 mt-2">Domains</p>
+                              <table class="table report report-table v3 border-grey-2 w-auto" data-financereport-target="domainSummaryTable"></table>
                            </div>
                            <p class="d-none mt-2" data-financereport-target="noReport">Data does not exist. Let's move on to another time!</p>
                            <div data-financereport-target="domainArea" class="d-none">

--- a/cmd/dcrdata/views/finance_report.tmpl
+++ b/cmd/dcrdata/views/finance_report.tmpl
@@ -352,12 +352,12 @@
                                  </div>
                               </div>
                               <div class="d-none" data-financereport-target="domainSummaryArea">
-                                 <p class="fw-600 fs-20 mt-2">Domains Summary</p>
+                                 <p class="fw-600 fs-20 mt-2">Domains</p>
                                  <table class="table report report-table v3 border-grey-2 w-auto" data-financereport-target="domainSummaryTable"></table>
                               </div>
                            </div>
                            <div class="mt-1 d-none" data-financereport-target="totalSpanRow">
-                              <p class="fw-600 fs-20 mt-3">Treasury Summary</p>
+                              <p class="fw-600 fs-20 mt-3">Treasury</p>
                               <table class="table report report-table v3 border-grey-2 w-auto" data-financereport-target="yearMonthInfoTable"></table>
                            </div>
                            <p class="d-none mt-2" data-financereport-target="noReport">Data does not exist. Let's move on to another time!</p>
@@ -366,7 +366,7 @@
                               <table class="table report report-table v3 border-grey-2 w-auto" data-financereport-target="domainReport"></table>
                            </div>
                            <div data-financereport-target="monthlyArea" class="d-none">
-                              <p class="fw-600 fs-20 mt-3">Monthly Summary</p>
+                              <p class="fw-600 fs-20 mt-3">Group By Time</p>
                               <div class="my-2 d-flex">
                                  <label class="color-note-label report-tool-bar border-radius-8 future-color"></label>
                                  <span data-financereport-target="detailMonthlyDesc" class="c-grey-2 ps-2 fw-600 color-description">Months in the future</span>
@@ -384,12 +384,12 @@
                               </div>
                            </div>
                            <div data-financereport-target="proposalArea" class="d-none">
-                              <p class="fw-600 fs-20 mt-3">Proposal Data</p>
+                              <p class="fw-600 fs-20 mt-3">Proposals</p>
                               <table class="table report report-table v3 border-grey-2 w-auto" data-financereport-target="proposalReport">
                               </table>
                            </div>
                            <div data-financereport-target="yearlyArea" class="d-none">
-                              <p class="fw-600 fs-20 mt-3">Yearly Summary</p>
+                              <p class="fw-600 fs-20 mt-3">Yearly</p>
                               <div class="my-2 d-flex">
                                  <label class="color-note-label report-tool-bar border-radius-8 future-color"></label>
                                  <span class="c-grey-2 ps-2 fw-600 color-description">Years in the future</span>


### PR DESCRIPTION
Related issue: #172 
Resolved: 
- Place Domains table below instead of above
- Do not show Summary in all areas
- Arrange boxes horizontally instead of one box per row to reduce space on the right
- Reverse month order in month selector